### PR TITLE
Fix reporducibility of the first example

### DIFF
--- a/src/trainer.py
+++ b/src/trainer.py
@@ -60,6 +60,8 @@ class Trainer(object):
         metric_sum = 0.0
         N = 0
 
+        self.model.eval()
+
         outputs_data = list()
         targets_data = list()
 


### PR DESCRIPTION
Getting reproducible results with the first example required setting quite a lot of seeds:

```python
seed = 113
torch.manual_seed(seed)
random.seed(seed)
np.random.seed(seed)

 if device == 'cuda':   
    # Ensure reproducibility with CUDA
    torch.cuda.manual_seed(seed)
    cudnn.deterministic = True
    cudnn.benchmark = False
```
and also calling `sefl.model.eval()` in `Trainer.evaluate`. This will set the model to evaluation mode, and will ensure reproducible results for the predictions.

More information here:
https://pytorch.org/docs/stable/notes/randomness.html
https://discuss.pytorch.org/t/training-reproducibility-problem/37143/20